### PR TITLE
Make it possible to mix strings and dicts in class_names list.

### DIFF
--- a/htpy/_attrs.py
+++ b/htpy/_attrs.py
@@ -4,12 +4,18 @@ from markupsafe import Markup, escape
 # Inspired by https://www.npmjs.com/package/classnames
 def class_names(value):
     if isinstance(value, list | tuple | set):
-        return Markup(" ").join(x for x in value if x)
+        return Markup(" ").join(
+            _dict_class_names(x) if isinstance(x, dict) else x for x in value if x
+        )
 
     if isinstance(value, dict):
-        return Markup(" ").join(k for k, v in value.items() if v)
+        return _dict_class_names(value)
 
     return escape(value)
+
+
+def _dict_class_names(value):
+    return Markup(" ").join(k for k, v in value.items() if v)
 
 
 def id_classnames_from_css_str(x):

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -121,3 +121,8 @@ def test_class_priority() -> None:
 def test_attribute_priority() -> None:
     result = div({"foo": "a"}, foo="b")
     assert str(result) == """<div foo="b"></div>"""
+
+
+def test_mixed_str_dict_class_attribute() -> None:
+    result = div(class_=("class-1", "class-2", {"class-3": False, "class-4": True}))
+    assert str(result) == """<div class="class-1 class-2 class-4"></div>"""


### PR DESCRIPTION
To further emulate [classnames](https://github.com/JedWatson/classnames) it would be nice if you could provide a mix of string and dicts in the list to `class_` (or `{"class": ...}`).  

For example `div(class_=("class-1", "class-2", {"class-3": False, "class-4": True}))` and it resulting in `<div class="class-1 class-2 class-4"></div>`