### PR TITLE
Docs: @with_children UI component pattern

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -138,3 +138,60 @@ print(
     )
 )
 ```
+
+### Maintaining htpy.Element behaviour
+
+You can maintain support for the `component(attr = value)[children]` syntax for
+your custom UI components, while maintaining type hints, with this decorator:
+
+```py title="Creating wrapper for Bootstrap Modal with component syntax"
+from __future__ import annotations
+
+import typing as t
+from collections.abc import Callable
+from dataclasses import dataclass
+from htpy import Element, Node, button, h1, div, p
+
+P = t.ParamSpec("P")
+R = t.TypeVar("R")
+C = t.TypeVar("C")
+
+
+@dataclass
+class _ChildrenWrapper(t.Generic[C, R]):
+    _component_func: t.Any
+    _args: t.Any
+    _kwargs: t.Any
+
+    def __getitem__(self, children: C) -> R:
+        return self._component_func(children, *self._args, **self._kwargs)  # type: ignore
+
+def with_children(
+    component_func: Callable[t.Concatenate[C, P], R],
+) -> Callable[P, _ChildrenWrapper[C, R]]:
+    def func(*args: P.args, **kwargs: P.kwargs) -> _ChildrenWrapper[C, R]:
+        return _ChildrenWrapper(component_func, args, kwargs)
+
+    return func
+
+#### Example Usage: ####
+
+@with_children
+def bs_button(style: t.Literal["success", "danger"], children: str) -> Element:
+    return button(class_=["btn", f"btn-{style}"])[children]
+
+
+@with_children
+def article_section(title: str, children: Node) -> Node:
+    return [h1[title], children]
+
+
+print(
+    div[
+        article_section("Check out htpy")[
+            p["Write HTML in Python!"],
+            bs_button("success")["Sign me up!"],
+        ]
+    ]
+)
+```


### PR DESCRIPTION
Add documentation for the pattern described in https://github.com/pelme/htpy/issues/6#issuecomment-2020337267

I've tried to make the example consistent with the patterns in the other examples (namely, importing each element individually rather than `import htpy as h`). 

Wasn't sure if this should live in docs/ or examples/ or both.