### PR TITLE
Update type of _ClassNames to Iterable

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -217,8 +217,7 @@ class _HasHtml(Protocol):
 
 _ClassNamesDict: TypeAlias = dict[str, bool]
 _ClassNames: TypeAlias = (
-    list[str | None | bool | _ClassNamesDict]
-    | tuple[str | None | bool | _ClassNamesDict, ...]
+    Iterable[str | None | bool | _ClassNamesDict]
     | _ClassNamesDict
 )
 Node: TypeAlias = None | str | BaseElement | _HasHtml | Iterable["Node"] | Callable[[], "Node"]

--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -216,10 +216,7 @@ class _HasHtml(Protocol):
 
 
 _ClassNamesDict: TypeAlias = dict[str, bool]
-_ClassNames: TypeAlias = (
-    Iterable[str | None | bool | _ClassNamesDict]
-    | _ClassNamesDict
-)
+_ClassNames: TypeAlias = Iterable[str | None | bool | _ClassNamesDict] | _ClassNamesDict
 Node: TypeAlias = None | str | BaseElement | _HasHtml | Iterable["Node"] | Callable[[], "Node"]
 
 Attribute: TypeAlias = None | bool | str | _HasHtml | _ClassNames


### PR DESCRIPTION
Iterables such as `set` should be allow in `_ClassNames`.