### PR TITLE
'vueish' html attributes with html2htpy

### DIFF
--- a/htpy/html2htpy.py
+++ b/htpy/html2htpy.py
@@ -61,6 +61,9 @@ class Tag:
                     _positional_attrs[key] = a[1]
                 else:
                     _kwattrs.append(a)
+            elif any(s in key for s in ["@", ":"]):
+                _positional_attrs[key] = a[1]
+                pass
             else:
                 _kwattrs.append(a)
 
@@ -74,6 +77,7 @@ class Tag:
                     raise Exception("Id attribute cannot be none")
 
                 arg0 += "#" + _positional_attrs["id"]
+                del _positional_attrs["id"]
 
             if "class" in _positional_attrs:
                 if _positional_attrs["class"] is None:
@@ -81,8 +85,23 @@ class Tag:
 
                 classes = ".".join(_positional_attrs["class"].split(" "))
                 arg0 += "." + classes
+                del _positional_attrs["class"]
 
             _attrs += '"' + arg0 + '",'
+
+            if _positional_attrs:
+                _attrs += "{"
+                for key in _positional_attrs:
+                    val = _positional_attrs[key]
+                    if not val:
+                        _attrs += f'"{key}":True,'
+                    else:
+                        val = _convert_data_to_string(val)
+                        _attrs += f'"{key}":{val},'
+
+                _attrs = _attrs[:-1]
+
+                _attrs += "},"
 
         if _kwattrs:
             for a in _kwattrs:
@@ -98,11 +117,11 @@ class Tag:
                 val = a[1]
                 if not val:
                     _attrs += f"{key}=True,"
-
                 else:
+                    val = val
                     _attrs += f'{key}="{val}",'
 
-        if _positional_attrs or _kwattrs:
+        if _attrs:
             _attrs = _attrs[:-1] + ")"
 
         _children: str = ""

--- a/tests/test_html2htpy.py
+++ b/tests/test_html2htpy.py
@@ -154,6 +154,22 @@ def test_convert_f_string_escaping() -> None:
     assert actual == expected
 
 
+def test_convert_vueish_attrs() -> None:
+    input = """
+      <button id="btn-id" @click="doSomething" type="submit">Submit</button>
+      <img id="img-id" :src="imageSrc" />
+    """
+
+    actual = html2htpy(input, import_mode="no")
+
+    assert actual == (
+        "["
+        'button("#btn-id",{"@click":"doSomething"},type="submit")["Submit"],'
+        'img("#img-id",{":src":"imageSrc"})'
+        "]"
+    )
+
+
 def test_convert_f_string_escaping_complex() -> None:
     input = """
     <body>


### PR DESCRIPTION
# 'vueish' html attributes with html2htpy 

`html2htpy` is not currently able to handle conversion of key word attributes prefixed with special characters such as `@click` or `:show`, which I stumped into while converting some templates containing attributes from alpine.js.

I added a test and a bit to the transformation algorithm to support converting these attributes to htpy's dictionary attr syntax.

```py
def test_convert_vueish_attrs() -> None:
    input = """
      <button id="btn-id" @click="doSomething" type="submit">Submit</button>
      <img id="img-id" :src="imageSrc" />
    """

    actual = html2htpy(input, import_mode="no") 
    assert actual == (
        "["
        'button("#btn-id",{"@click":"doSomething"},type="submit")["Submit"],'
        'img("#img-id",{":src":"imageSrc"})'
        "]"
    )
```