### PR TITLE
Handle "False" child elements

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -107,7 +107,7 @@ def iter_node(x: Node) -> Iterator[str]:
     while not isinstance(x, BaseElement) and callable(x):
         x = x()
 
-    if x is None:
+    if x is None or x is False:
         return
 
     if isinstance(x, BaseElement):


### PR DESCRIPTION
I'm submitting this tiny change to improve conditional rendering.

Currently, only "None" nodes are skipped.
This is useful to implement conditional rendering based on a nullable variable, as shown in the docs.

`print(div[error and b[error]])`

Unfortunately, most conditional rendering often relies on a boolean condition, and in this case, you can't do `print(div[has_error and b[error_msg]])` because you will get an error `ValueError: False is not a valid child element`

The current best way to have conditional rendering based on a boolean is to adopt the ternary operator `print(div[b[error_msg] if has_error else None])`.

Drawbacks are:
- condition appears after the (often very long) block, making it hard to read
- you still have to have to write the `else None` part all the time, which is tedious

The suggested change aims to allow the `print(div[has_error and b[error_msg]])` syntax for boolean conditional rendering.
