### PR TITLE
Update __init__.py

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -222,7 +222,7 @@ class BaseElement:
         self._children = children
 
     def __str__(self) -> _Markup:
-        return _Markup("".join(str(x) for x in self))
+        return _Markup("".join(self))
 
     @t.overload
     def __call__(


### PR DESCRIPTION
Removes the generator.

Self is already iterable so an additional generator is overhead.  I think this may have been useful at some point because other data types may have been allowed?  (Which would need to be converted to string before join.)

However, `_iter_node_context()` currently prevents this.  Unexpected data types result in a ValueError (which probably should be a TypeError, now that I think of it), everything else is ultimately converted to string.

I get around a 2% speedup from your benchmark script with the generator removed.  Not a huge difference but better than a poke in the eye. 

