### PR TITLE
build: 🛠 add upper boundary to Markupsafe to avoid breaking changes from unreleased v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "htpy - HTML in Python"
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "markupsafe>=2.0.0"
+    "markupsafe>=2.0.0,<3"
 ]
 readme = "docs/README.md"
 authors = [


### PR DESCRIPTION
v3.0 of Markupsafe is described as [unreleased and not stable](https://markupsafe.palletsprojects.com/en/latest/changes/), yet it is already on [pypi](https://pypi.org/project/MarkupSafe/#history). To avoid using it prematurely, we need to add this upper boundary.