### PR TITLE
Make possible to use one-shot iterators as children nodes.

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -296,10 +296,7 @@ class BaseElement:
     do_not_call_in_templates = True
 
 
-_T = t.TypeVar("_T", bound=t.Any)
-
-
-def _validate_children(children: _T) -> _T | t.Iterable[t.Any] | None:
+def _validate_children(children: t.Any) -> t.Any:
     if isinstance(children, _KnownValidChildren):
         return children
 

--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -295,9 +295,11 @@ class BaseElement:
     # https://docs.djangoproject.com/en/5.0/ref/templates/api/#variables-and-lookups
     do_not_call_in_templates = True
 
+
 _T = t.TypeVar("_T", bound=t.Any)
 
-def _validate_children(children: _T) -> _T | t.Iterable[t.Any] | t.Never:
+
+def _validate_children(children: _T) -> _T | t.Iterable[t.Any] | None:
     if isinstance(children, _KnownValidChildren):
         return children
 

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -115,9 +115,15 @@ def test_one_shot_iterator_children(render: RenderFixture) -> None:
     result = ul[gen]
     assert render(result) == [
         "<ul>",
-        "<li>", "a", "</li>",
-        "<li>", "b", "</li>",
-        "<li>", "c", "</li>",
+        "<li>",
+        "a",
+        "</li>",
+        "<li>",
+        "b",
+        "</li>",
+        "<li>",
+        "c",
+        "</li>",
         "</ul>",
     ]
 

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -6,6 +6,7 @@ import decimal
 import pathlib
 import re
 import typing as t
+from itertools import chain
 
 import pytest
 from markupsafe import Markup
@@ -107,6 +108,18 @@ def test_generator_children(render: RenderFixture) -> None:
     gen: Generator[Element, None, None] = (li[x] for x in ["a", "b"])
     result = ul[gen]
     assert render(result) == ["<ul>", "<li>", "a", "</li>", "<li>", "b", "</li>", "</ul>"]
+
+
+def test_one_shot_iterator_children(render: RenderFixture) -> None:
+    gen: chain[Element] = chain([li["a"]], chain([li["b"]], [li["c"]]))
+    result = ul[gen]
+    assert render(result) == [
+        "<ul>",
+        "<li>", "a", "</li>",
+        "<li>", "b", "</li>",
+        "<li>", "c", "</li>",
+        "</ul>",
+    ]
 
 
 def test_html_tag_with_doctype(render: RenderFixture) -> None:


### PR DESCRIPTION
For now we cannot use iterators like `itertools.chain` as child nodes, because `_validate_children` exhaust such iterators just before the parent node construction. The result looks like original sequences were empty. Yes, user could apply `list()` such iterators but then the code would look pretty noisy.

I propose to "materialise" as lists such iterators, because we would reuse them anyway during the HTML rendering. We can use the `itertools.tee` and fork each `Iterator` before validation. Though, such forking would mean the same materialisation under the hood, but at the same time the code would look a way more complicated.