### PR TITLE
Fixed handling of non-generator iterators

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## NEXT
+- Fixed handling of non-generator iterators such as `itertools.chain()` as
+children. Thanks to Aleksei Pirogov ([@astynax](https://github.com/astynax)).
+[PR #72](https://github.com/pelme/htpy/pull/72).
+
 ## 24.10.1 - 2024-10-24
 - Fix handling of Python keywords such as `<del>` in html2htpy. [PR #61](https://github.com/pelme/htpy/pull/61).
 


### PR DESCRIPTION
Previously there were checks for generators specifically and not iterators in general. We also support one-off iterators that are not based on generators such as itertools.chain().

This regression was introduced in https://github.com/pelme/htpy/pull/56.

Based on https://github.com/pelme/htpy/pull/71.