### PR TITLE
Type attrs as Mapping instead of dict

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -234,7 +234,7 @@ class BaseElement:
 
     @t.overload
     def __call__(
-        self: BaseElementSelf, id_class: str, attrs: dict[str, Attribute], **kwargs: Attribute
+        self: BaseElementSelf, id_class: str, attrs: t.Mapping[str, Attribute], **kwargs: Attribute
     ) -> BaseElementSelf: ...
     @t.overload
     def __call__(
@@ -242,7 +242,7 @@ class BaseElement:
     ) -> BaseElementSelf: ...
     @t.overload
     def __call__(
-        self: BaseElementSelf, attrs: dict[str, Attribute], **kwargs: Attribute
+        self: BaseElementSelf, attrs: t.Mapping[str, Attribute], **kwargs: Attribute
     ) -> BaseElementSelf: ...
     @t.overload
     def __call__(self: BaseElementSelf, **kwargs: Attribute) -> BaseElementSelf: ...


### PR DESCRIPTION
In the example below, the type of `attributes` is inferred as `dict[str, str]`. Type checkers will complain about `BaseElement` not accepting an argument of that type. The reason is that `dict` is invariant but `typing.Mapping` is covariant.

```
from htpy import div
attributes = {"foo": "bar"}
div(attributes)
```

```
$ mypy
components.py:3: error: Argument 1 to "__call__" of "BaseElement" has incompatible type "dict[str, str]"; expected "dict[str, bool | str | int | _HasHtml | Iterable[str | bool | dict[str, bool] | None] | dict[str, bool] | None]"  [arg-type]
components.py:3: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
components.py:3: note: Consider using "Mapping" instead, which is covariant in the value type
Found 1 error in 1 file (checked 1 source files)
```