### PR TITLE
Simplify f string tests.

### DIFF
--- a/htpy/html2htpy.py
+++ b/htpy/html2htpy.py
@@ -278,7 +278,7 @@ class HTPYParser(HTMLParser):
             sorted_tags = list(unique_tags)
             sorted_tags.sort()
 
-            o += f'from htpy import {", ".join(sorted_tags)}\n'
+            o += f"from htpy import {', '.join(sorted_tags)}\n"
 
         elif import_mode == "h":
             o += "import htpy as h\n"

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -45,8 +45,7 @@ class Test_class_names:
             ]
         )
         assert render(result) == [
-            '<div class="&#34;&gt;list-foo &#34;&gt;list-bar '
-            '&#34;&gt;dict-foo &#34;&gt;list-bar">',
+            '<div class="&#34;&gt;list-foo &#34;&gt;list-bar &#34;&gt;dict-foo &#34;&gt;list-bar">',
             "</div>",
         ]
 

--- a/tests/test_html2htpy.py
+++ b/tests/test_html2htpy.py
@@ -145,50 +145,11 @@ def test_convert_special_characters() -> None:
 
 def test_convert_f_string_escaping() -> None:
     input = """
-        <p>{{ variable }} is "a" { paragraph }.</p>
+        <p>{{ variable }} is "a" { paragraph } {{ variable.with.attrib }}.</p>
     """
 
     actual = html2htpy(input, import_mode="no")
-    expected = r'p[f"{ variable } is \"a\" {{ paragraph }}."]'
-
-    assert actual == expected
-
-
-def test_convert_f_string_escaping_complex() -> None:
-    input = """
-    <body>
-        <h1>{{ heading }}</h1>
-        <p>Welcome to our cooking site, {{ user.name }}!</p>
-
-        <h2>Recipe of the Day: {{ recipe.name }}</h2>
-        <p>{{ recipe.description }}</p>
-
-        <h3>Instructions:</h3>
-        <ol>
-            {% for step in recipe.steps %}
-            <li>{{ step }}</li>
-            {% endfor %}
-        </ol>
-    </body>
-    """
-
-    actual = html2htpy(input, formatter=RuffFormatter(), import_mode="no")
-    expected = textwrap.dedent(
-        """\
-        body[
-            h1[f"{ heading }"],
-            p[f"Welcome to our cooking site, { user.name }!"],
-            h2[f"Recipe of the Day: { recipe.name }"],
-            p[f"{ recipe.description }"],
-            h3["Instructions:"],
-            ol[
-                \"\"\"            {% for step in recipe.steps %}            \"\"\",
-                li[f"{ step }"],
-                \"\"\"            {% endfor %}        \"\"\",
-            ],
-        ]
-    """
-    )
+    expected = r'p[f"{ variable } is \"a\" {{ paragraph }} { variable.with.attrib }."]'
 
     assert actual == expected
 

--- a/tests/test_html2htpy.py
+++ b/tests/test_html2htpy.py
@@ -103,7 +103,7 @@ def test_convert_custom_element_include_imports() -> None:
     actual = html2htpy(input, import_mode="yes")
 
     assert actual == (
-        "from htpy import custom_element\n" 'custom_element(attribute="value")["Custom content"]'
+        'from htpy import custom_element\ncustom_element(attribute="value")["Custom content"]'
     )
 
 


### PR DESCRIPTION
There were two tests that tested the same functionality. The second test
depended on ruff formatting. Changes to rust formatting rules broke the test.

### Relation chain
-  #78
- 👉 #79