### PR TITLE
Allow any node in context provider

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -406,15 +406,14 @@ Using contexts in htpy involves:
 
 - Creating a context object with `my_context = Context(name[, *, default])` to
 define the type and optional default value of a context variable.
-- Using `my_context.provider(value, lambda: children)` to set the value of a context variable for a subtree.
+- Using `my_context.provider(value, children)` to set the value of a context variable for a subtree.
 - Adding the `@my_context.consumer` decorator to a component that requires the
 context value. The decorator will add the context value as the first argument to the decorated function:
 
 The `Context` class is a generic and fully supports static type checking.
 
 The values are passed as part of the tree used to render components without
-using global state. It is safe to use contexts for lazy constructs such as
-callables and generators.
+using global state.
 
 A context value can be passed arbitrarily deep between components. It is
 possible to nest multiple context provider and different values can be used in
@@ -437,7 +436,7 @@ This example shows how context can be used to pass data between components:
 - `theme_context: Context[Theme] = Context("theme", default="light")` creates a
 context object that can later be used to define/retrieve the value. In this
 case, `"light"` acts as the default value if no other value is provided.
-- `theme_context.provider(value, lambda: subtree)` defines the value of the
+- `theme_context.provider(value, subtree)` defines the value of the
 `theme_context` for the subtree. In this case the value is set to `"dark"` which
 overrides the default value.
 - The `sidebar` component uses the `@theme_context.consumer` decorator. This

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -459,7 +459,7 @@ theme_context: Context[Theme] = Context("theme", default="light")
 def my_page() -> Node:
     return theme_context.provider(
         "dark",
-        lambda: div[
+        div[
             h1["Hello!"],
             sidebar("The Sidebar!"),
         ],

--- a/examples/context.py
+++ b/examples/context.py
@@ -10,7 +10,7 @@ theme_context: Context[Theme] = Context("theme", default="light")
 def my_page() -> Node:
     return theme_context.provider(
         "dark",
-        lambda: div[
+        div[
             h1["Hello!"],
             sidebar("The Sidebar!"),
         ],

--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -128,7 +128,7 @@ P = t.ParamSpec("P")
 class ContextProvider(t.Generic[T]):
     context: Context[T]
     value: T
-    func: Callable[[], Node]
+    node: Node
 
     def __iter__(self) -> Iterator[str]:
         return iter_node(self)
@@ -153,8 +153,8 @@ class Context(t.Generic[T]):
         self.name = name
         self.default = default
 
-    def provider(self, value: T, children_func: Callable[[], Node]) -> ContextProvider[T]:
-        return ContextProvider(self, value, children_func)
+    def provider(self, value: T, node: Node) -> ContextProvider[T]:
+        return ContextProvider(self, value, node)
 
     def consumer(
         self,
@@ -187,7 +187,7 @@ def _iter_node_context(x: Node, context_dict: dict[Context[t.Any], t.Any]) -> It
     if isinstance(x, BaseElement):
         yield from x._iter_context(context_dict)  # pyright: ignore [reportPrivateUsage]
     elif isinstance(x, ContextProvider):
-        yield from _iter_node_context(x.func(), {**context_dict, x.context: x.value})  # pyright: ignore [reportUnknownMemberType]
+        yield from _iter_node_context(x.node, {**context_dict, x.context: x.value})  # pyright: ignore [reportUnknownMemberType]
     elif isinstance(x, ContextConsumer):
         context_value = context_dict.get(x.context, x.context.default)
         if context_value is _NO_DEFAULT:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -30,7 +30,7 @@ def test_context_default(render: RenderFixture) -> None:
 
 
 def test_context_provider(render: RenderFixture) -> None:
-    result = letter_ctx.provider("c", lambda: div[display_letter("Hello")])
+    result = letter_ctx.provider("c", div[display_letter("Hello")])
     assert render(result) == ["<div>", "Hello: c!", "</div>"]
 
 
@@ -38,11 +38,11 @@ class Test_provider_outer_api:
     """Ensure provider implements __iter__/__str__"""
 
     def test_iter(self) -> None:
-        result = letter_ctx.provider("c", lambda: div[display_letter("Hello")])
+        result = letter_ctx.provider("c", div[display_letter("Hello")])
         assert list(result) == ["<div>", "Hello: c!", "</div>"]
 
     def test_str(self) -> None:
-        result = str(letter_ctx.provider("c", lambda: div[display_letter("Hello")]))
+        result = str(letter_ctx.provider("c", div[display_letter("Hello")]))
         assert result == "<div>Hello: c!</div>"
         assert isinstance(result, markupsafe.Markup)
 
@@ -59,9 +59,9 @@ def test_nested_override(render: RenderFixture) -> None:
     result = div[
         letter_ctx.provider(
             "b",
-            lambda: letter_ctx.provider(
+            letter_ctx.provider(
                 "c",
-                lambda: display_letter("Nested"),
+                display_letter("Nested"),
             ),
         )
     ]
@@ -104,6 +104,6 @@ def test_context_passed_via_iterable(render: RenderFixture) -> None:
     def echo(value: str) -> str:
         return value
 
-    result = div[ctx.provider("foo", lambda: [echo()])]
+    result = div[ctx.provider("foo", [echo()])]
 
     assert render(result) == ["<div>", "foo", "</div>"]


### PR DESCRIPTION
Maybe I’m missing something here, but when I played around with contexts I noticed that you don’t need to pass a function to a context provider. Context consumers need to be function to delay evaluation until the context is available and this is taken care of by the decorator.