### PR TITLE
Construct fragment via fragment[].

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Next (minor)
-- Add a `Fragment` node for explicitly grouping a collection of nodes. Fixes
-[#82](https://github.com/pelme/htpy/issues/82)
+- Add `fragment` for explicitly grouping a collection of nodes. [Read the Usage docs for more details](usage.md#fragments) Fixes
+[issue #82](https://github.com/pelme/htpy/issues/82).
+See [PR #86](https://github.com/pelme/htpy/pull/86) and [PR #95](https://github.com/pelme/htpy/pull/95). Thanks to [Thomas Scholtes (@geigerzaehler)](https://github.com/geigerzaehler).
 
 ## 25.2.0 - 2025-02-01
 - Context providers longer require wrapping nodes in a function/lambda. This

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -98,8 +98,8 @@ Fragments allow you to wrap a group of nodes (not necessarily elements) so that
 they can be rendered without a wrapping element.
 
 ```pycon
->>> from htpy import p, i, Fragment
->>> content = Fragment("Hello ", None, i["world!"])
+>>> from htpy import p, i, fragment
+>>> content = fragment["Hello ", None, i["world!"]]
 >>> print(content)
 Hello <i>world!</i>
 
@@ -404,8 +404,8 @@ Just like [render_node()](#render-elements-without-a-parent-orphans), there is
 without a parent:
 
 ```pycon
->>> from htpy import li, iter_node
->>> for chunk in iter_node([li["a"], li["b"]]):
+>>> from htpy import li, Fragment
+>>> for chunk in fragment[li["a"], li["b"]]:
 ...     print(f"got a chunk: {chunk!r}")
 ...
 got a chunk: '<li>'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -5,7 +5,7 @@ import typing as t
 import markupsafe
 import pytest
 
-from htpy import Context, Fragment, Node, div
+from htpy import Context, Node, div, fragment
 
 if t.TYPE_CHECKING:
     from .conftest import RenderFixture
@@ -116,6 +116,6 @@ def test_context_passed_via_fragment(render: RenderFixture) -> None:
     def echo(value: str) -> str:
         return value
 
-    result = div[ctx.provider("foo", Fragment(echo()))]
+    result = div[ctx.provider("foo", fragment[echo()])]
 
     assert render(result) == ["<div>", "foo", "</div>"]

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -1,16 +1,16 @@
 import markupsafe
 
-from htpy import Fragment, i, p
+from htpy import fragment, i, p
 
 from .conftest import RenderFixture
 
 
 def test_render_direct() -> None:
-    assert str(Fragment("Hello ", None, i["World"])) == "Hello <i>World</i>"
+    assert str(fragment["Hello ", None, i["World"]]) == "Hello <i>World</i>"
 
 
 def test_render_as_child(render: RenderFixture) -> None:
-    assert render(p["Say: ", Fragment("Hello ", None, i["World"]), "!"]) == [
+    assert render(p["Say: ", fragment["Hello ", None, i["World"]], "!"]) == [
         "<p>",
         "Say: ",
         "Hello ",
@@ -23,11 +23,11 @@ def test_render_as_child(render: RenderFixture) -> None:
 
 
 def test_render_nested(render: RenderFixture) -> None:
-    assert render(Fragment(Fragment("Hel", "lo "), "World")) == ["Hel", "lo ", "World"]
+    assert render(fragment[fragment["Hel", "lo "], "World"]) == ["Hel", "lo ", "World"]
 
 
 def test_render_chunks(render: RenderFixture) -> None:
-    assert render(Fragment("Hello ", None, i["World"])) == [
+    assert render(fragment["Hello ", None, i["World"]]) == [
         "Hello ",
         "<i>",
         "World",
@@ -36,8 +36,8 @@ def test_render_chunks(render: RenderFixture) -> None:
 
 
 def test_safe() -> None:
-    assert markupsafe.escape(Fragment(i["hi"])) == "<i>hi</i>"
+    assert markupsafe.escape(fragment[i["hi"]]) == "<i>hi</i>"
 
 
 def test_iter() -> None:
-    assert list(Fragment("Hello ", None, i["World"])) == ["Hello ", "<i>", "World", "</i>"]
+    assert list(fragment["Hello ", None, i["World"]]) == ["Hello ", "<i>", "World", "</i>"]


### PR DESCRIPTION
This change makes the fragment consistent with elements by using
__getitem__ to specify child nodes.

See https://github.com/pelme/htpy/discussions/93 for discussion.

### Relation chain
-  #92
- 👉 #95