### PR TITLE
Make Context's repr debug friendly

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -148,10 +148,11 @@ class _NO_DEFAULT:
     pass
 
 
+@dataclasses.dataclass(frozen=True)
 class Context(t.Generic[T]):
-    def __init__(self, name: str, *, default: T | type[_NO_DEFAULT] = _NO_DEFAULT) -> None:
-        self.name = name
-        self.default = default
+    name: str
+    _: dataclasses.KW_ONLY
+    default: T | type[_NO_DEFAULT] = _NO_DEFAULT
 
     def provider(self, value: T, node: Node) -> ContextProvider[T]:
         return ContextProvider(self, value, node)


### PR DESCRIPTION
When viewing `Context`s in stack traces/debuggers, it was not obvious which context one was looking at, especially if multiple contexts had values of similar types. With this change, the context name is visible in e.g. Django's debug mode exception page.

Since dataclasses are already in use for other classes in htpy, I opted to make the `Context` class a dataclass too. The constructor should be exactly the same before and after this change.

Before:

```
<htpy.Context object at 0x7f9af95a16d0>: <<Request: GET '/foo/bar/'> at 0x7f9af5e88410>
```

After:

```
Context(name='request', default=<class 'htpy._NO_DEFAULT'>): <<Request: GET '/foo/bar/'> at 0x7fab5e7a6ad0>
```