### PR TITLE
Fix import of `deprecated()` annotation on Python >= 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"
@@ -39,6 +40,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
@@ -53,6 +55,7 @@ jobs:
   pyright:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 25.4.2 - 2025-04-16
+- Fix import of `@deprecated()` annotation on Python >= 3.13. It is part of the `warnings` module, not the `typing` module. Fixes [issue #106]. [PR #107]
+
 ## 25.4.1 - 2025-04-12
 - Add the `Renderable` protocol, a consistent API to render an `htpy` object as HTML or to iterate over it. `Element`, `Fragment`, `ContextProvider`, and `ContextConsumer` are all `Renderable`. [PR #92](https://github.com/pelme/htpy/pull/92). Thanks to  [Stein Magnus Jodal (@jodal)](https://github.com/jodal) and [Dave Peck (@davepeck)](https://github.com/davepeck).
 - Deprecate `render_node()` and `iter_node()` and direct iteration over elements. Call `Renderable.__str__()` or `Renderable.iter_chunks()` instead. [Read the Usage docs for more details](usage.md#renderable).

--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -10,7 +10,7 @@ from markupsafe import Markup as _Markup
 from markupsafe import escape as _escape
 
 try:
-    from typing import deprecated  # type: ignore[attr-defined]
+    from warnings import deprecated  # type: ignore[attr-defined,unused-ignore]
 except ImportError:
     from typing_extensions import deprecated
 
@@ -135,7 +135,7 @@ class ContextProvider(t.Generic[T]):
     value: T
     node: Node
 
-    @deprecated(
+    @deprecated(  # type: ignore[misc,unused-ignore]
         "iterating over a context provider is deprecated and will be removed in a future release. "
         "Please use the context_provider.iter_chunks() method instead."
     )  # pyright: ignore [reportUntypedFunctionDecorator]
@@ -203,7 +203,7 @@ class Context(t.Generic[T]):
         return wrapper
 
 
-@deprecated(
+@deprecated(  # type: ignore[misc,unused-ignore]
     "iter_node is deprecated and will be removed in a future release. "
     "Please use the .iter_chunks() method on elements/fragments instead."
 )  # pyright: ignore [reportUntypedFunctionDecorator]
@@ -306,7 +306,7 @@ class BaseElement:
             self._children,
         )
 
-    @deprecated(
+    @deprecated(  # type: ignore[misc,unused-ignore]
         "iterating over an element is deprecated and will be removed in a future release. "
         "Please use the element.iter_chunks() method instead."
     )  # pyright: ignore [reportUntypedFunctionDecorator]
@@ -386,7 +386,7 @@ class Fragment:
         # node directly via the constructor.
         self._node: Node = None
 
-    @deprecated(
+    @deprecated(  # type: ignore[misc,unused-ignore]
         "iterating over a fragment is deprecated and will be removed in a future release. "
         "Please use the fragment.iter_chunks() method instead."
     )  # pyright: ignore [reportUntypedFunctionDecorator]
@@ -419,7 +419,7 @@ def _chunks_as_markup(renderable: Renderable) -> _Markup:
     return _Markup("".join(renderable.iter_chunks()))
 
 
-@deprecated(
+@deprecated(  # type: ignore[misc,unused-ignore]
     "render_node is deprecated and will be removed in a future release. "
     "Please use fragment instead: https://htpy.dev/usage/#fragments"
 )  # pyright: ignore [reportUntypedFunctionDecorator]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "markupsafe>=2.0.0",
-    # typing_extensions is used for @typing.deprecated introduced in Python 3.13
+    # typing_extensions is used for @warnings.deprecated introduced in Python 3.13
     "typing_extensions>=4.13.2 ; python_version<'3.13'",
 ]
 readme = "docs/README.md"


### PR DESCRIPTION
It is part of the `warnings` module, not the `typing` module.

Fixes #106