### PR TITLE
Ignore .*_cache and *.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-/.venv
-__pycache__
-/dist
-/site
-.env
 *.sqlite3
+/*.lock
+/.*_cache/
+/.env
+/.venv/
+/dist/
+/site/
+__pycache__/


### PR DESCRIPTION
So that one can use e.g. uv without accidentally committing the lock file.