### PR TITLE
Allow passing multiple attrs args into components

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -265,7 +265,7 @@ class BaseElement:
 
     @t.overload
     def __call__(
-        self: BaseElementSelf, id_class: str, attrs: Mapping[str, Attribute], **kwargs: Attribute
+        self: BaseElementSelf, id_class: str, *attrs: Mapping[str, Attribute], **kwargs: Attribute
     ) -> BaseElementSelf: ...
     @t.overload
     def __call__(
@@ -273,26 +273,26 @@ class BaseElement:
     ) -> BaseElementSelf: ...
     @t.overload
     def __call__(
-        self: BaseElementSelf, attrs: Mapping[str, Attribute], **kwargs: Attribute
+        self: BaseElementSelf, *attrs: Mapping[str, Attribute], **kwargs: Attribute
     ) -> BaseElementSelf: ...
     @t.overload
     def __call__(self: BaseElementSelf, **kwargs: Attribute) -> BaseElementSelf: ...
     def __call__(self: BaseElementSelf, *args: t.Any, **kwargs: t.Any) -> BaseElementSelf:
         id_class = ""
+        attrs_dicts: list[Mapping[str, Attribute]] = []
         attrs: Mapping[str, Attribute] = {}
 
-        if len(args) == 1:
-            if isinstance(args[0], str):
+        if args:
+            if not isinstance(args[0], Mapping):
                 # element(".foo")
-                id_class = args[0]
-                attrs = {}
+                id_class, *attrs_dicts = args
             else:
                 # element({"foo": "bar"})
                 id_class = ""
-                attrs = args[0]
-        elif len(args) == 2:
-            # element(".foo", {"bar": "baz"})
-            id_class, attrs = args
+                attrs_dicts = args
+
+        for attr_dict in attrs_dicts:
+            attrs.update(attr_dict)
 
         return self.__class__(
             self._name,

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -187,13 +187,18 @@ def test_id_class_bad_format() -> None:
 
 
 def test_id_class_bad_type() -> None:
-    with pytest.raises(TypeError, match="id/class strings must be str. got {'oops': 'yes'}"):
-        div({"oops": "yes"}, {})  # type: ignore
+    with pytest.raises(TypeError, match="id/class strings must be str. got 3"):
+        div(3, {})  # type: ignore
 
 
 def test_id_class_and_kwargs(render: RenderFixture) -> None:
     result = div("#theid", for_="hello", data_foo="<bar")
     assert render(result) == ['<div id="theid" for="hello" data-foo="&lt;bar">', "</div>"]
+
+
+def test_multiple_attrs(render: RenderFixture) -> None:
+    result = div({"a": "1"}, {"a": "2", "b": "2"}, {"c": "3"})
+    assert render(result) == ['<div a="2" b="2" c="3">', "</div>"]
 
 
 def test_attrs_and_kwargs(render: RenderFixture) -> None:


### PR DESCRIPTION
Allows passing more than one dict of arguments into an element. Can be useful if you have a helper function that generates a single attribute. This would let you use that helper more than once on the same element.