### PR TITLE
Leave pre-formatted kwarg attributes as-is

### DIFF
--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -81,6 +81,9 @@ def _id_class_names_from_css_str(x: t.Any) -> Mapping[str, Attribute]:
 
 
 def _python_to_html_name(name: str) -> str:
+    # If the name already has a dash in it, we presume that it's already user formatted.
+    if "-" in name:
+        return name
     # Make _hyperscript (https://hyperscript.org/) work smoothly
     if name == "_":
         return "_"

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -103,6 +103,11 @@ def test_underscore_replacement(render: RenderFixture) -> None:
     assert render(result) == ['<button hx-post="/foo">', "click me!", "</button>"]
 
 
+def test_already_formatted_attributes(render: RenderFixture) -> None:
+    result = button(**{"data-foo__bar": "value"})
+    assert render(result) == ['<button data-foo__bar="value">', "</button>"]
+
+
 class Test_attribute_escape:
     pytestmark = pytest.mark.parametrize(
         "x",


### PR DESCRIPTION
Prevents the underscore replacement in attribute names if the name already has a dash, e.g.:

```python
div(**{'data-my-weird_attribute': value})
```
```
<div data-my-weird_attribute="value"></div>
```
Previously the underscore would have been written as a dash.

Motivation is to be able to use datastar attributes, which have both dashes and underscores.
Since the only way to get dashes in the kwargs dict is to unpack them from a dict on the calling side this feels pretty safe. Similar to how attributes are not rewritten when they are passed in a dict as the first argument.