### PR TITLE
Drop flit from packages.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 [dependency-groups]
 dev = [
     "pre-commit",
-    "flit",
     "mypy",
     "pyright",
     "pytest",


### PR DESCRIPTION
uv build / uv publish can be used to release the package.