### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/htpy/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch history and tags to enable correct versioning
+          fetch-depth: 0
+      - uses: hynek/build-and-inspect-python-package@v2
+        id: build
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.build.outputs.artifact-name }}
+          path: dist
+      - uses: https://github.com/pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This workflow is triggered by the creation of a new GitHub release, which can be done through the GitHub UI, the GitHub CLI `gh`, or the GitHub API.

It builds the release artifacts using the https://github.com/hynek/build-and-inspect-python-package action, which is agnostic to what packaging tool is used, as long as it follows the Python packaging standards, which uv does.

This action also makes the artifacts available for download from the GitHub Actions UI, and outputs listings of the tarball and wheel for inspection. This step could be added to the regular CI build too, without any changes, so that the packages can be inspected without making a release. I'm leaving that for later.

Next, the workflow downloads the artifact from the build step and uploads it using PyPA's https://github.com/pypa/gh-action-pypi-publish action, which supports PyPI's Trusted Publishing as described on https://docs.pypi.org/trusted-publishers/

Before the first release, the PyPI project must be set up to support Trusted Publishing at https://pypi.org/manage/project/htpy/settings/publishing/ with the following settings:

- Publisher: GitHub
- PyPI project name: `htpy`
- Owner: `pelme`
- Repository name: `htpy`
- Workflow name: `release.yml`
- Environment name: `pypi` (must match environment name in `release.yml`)

Fixes #126