### PR TITLE
Build with VCS-based versioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,15 @@ jobs:
           python-version: "3.13"
       - run: uv run pre-commit run --all-files
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch history and tags to enable correct versioning
+          fetch-depth: 0
+      - uses: hynek/build-and-inspect-python-package@v2
+
   pytest:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.sqlite3
+/*.egg-info/
 /*.lock
 /.*_cache/
 /.env
+/.jj/
 /.venv/
 /dist/
 /site/

--- a/htpy/__init__.py
+++ b/htpy/__init__.py
@@ -17,7 +17,6 @@ from htpy._types import Node as Node
 from htpy._types import Renderable as Renderable
 from htpy._with_children import with_children as with_children
 
-__version__ = "25.5.1"
 __all__: list[str] = []
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,10 @@ Issues = "https://github.com/pelme/htpy/issues"
 html2htpy = "htpy.html2htpy:main"
 
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
 
-[tool.flit.module]
-name = "htpy"
+[tool.setuptools_scm]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ readme = "docs/README.md"
 authors = [
   { name="Andreas Pelme", email="andreas@pelme.se" },
 ]
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Development Status :: 4 - Beta",
     "Topic :: Text Processing :: Markup :: HTML",


### PR DESCRIPTION
Ref the discussion in #129, I attempted to switch build backend from `flit` to `hatchling` + `hatch-vcs` to get package versioning based on Git tags, to further simplify the release process.

I've checked using `diffoscope` that the produces wheels before and after are equivalent. The new tarball is a lot larger, because it includes everything in the repo that is not ignored by Git, like docs and examples. With my Debian Python Team hat on, I argue that this is exactly what we want from a tarball, and strictly an improvement. The wheel is the small and fast way to install the package. The tarball is the complete package, equivalent to the Git repo, that can be used for packaging htpy in e.g. Linux distros.

I included a commit that updated `htpy.__version__` to be based on the packaging metadata. If you're open to it, I'd instead remove `htpy.__version__` entirely, and avoid the extra overhead of reading the package metadata on each import. I think the Python ecosystem are slowly moving away from `__version__` towards anyone needing versions just using `importlib.metadata.version(package_name)` instead of `package_name.__version__`.

Finally, I added a build step to CI, which will produce wheels and tarballs that can be downloaded for inspection, and also lists the package contents directly in the GitHub Actions UI.