### PR TITLE
Setup tox to run checks locally and in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,15 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: "3.13"
-      - run: uv run pre-commit run --all-files
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -24,46 +15,49 @@ jobs:
           fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@v2
 
-  pytest:
-    runs-on: ubuntu-latest
+  tests:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
+        include:
+          - name: pytest (3.10)
+            python: "3.10"
+            tox: "3.10"
+          - name: pytest (3.11)
+            python: "3.11"
+            tox: "3.11"
+          - name: pytest (3.12)
+            python: "3.12"
+            tox: "3.12"
+          - name: pytest (3.13)
+            python: "3.13"
+            tox: "3.13"
+            coverage: true
+          - name: pytest (3.14)
+            python: "3.14"
+            tox: "3.14"
+          - name: mypy
+            python: "3.13"
+            tox: mypy
+          - name: pyright
+            python: "3.13"
+            tox: pyright
+          - name: ruff format
+            python: "3.13"
+            tox: ruff-format
+          - name: ruff check
+            python: "3.13"
+            tox: ruff-check
+          - name: docs
+            python: "3.13"
+            tox: docs
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv run pytest
-
-  mypy:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv run mypy
-
-  pyright:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv run pyright
+          python-version: ${{ matrix.python }}
+          activate-environment: true
+      - run: uv pip install tox tox-uv
+      - run: tox -e ${{ matrix.tox }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,21 +22,29 @@ classifiers = [
 
 [dependency-groups]
 dev = [
+    "pre-commit",
+    { include-group = "docs" },
+    { include-group = "mypy" },
+    { include-group = "pyright" },
+    { include-group = "ruff" },
+    { include-group = "tests" },
+]
+docs = ["mkdocs-material==9.5.12"]
+mypy = ["mypy"]
+pyright = ["pyright"]
+ruff = ["ruff"]
+tests = [
     "black",
     "django",
     "django-stubs",
     "httpx",
     "jinja2",
     "markdown",
-    "mypy",
-    "pre-commit",
-    "pyright",
     "pytest",
     "pytest-doctestplus",
     "ruff",
     "starlette",
 ]
-docs = ["mkdocs-material==9.5.12"]
 
 [project.urls]
 Homepage = "https://htpy.dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ dependencies = [
     "typing_extensions>=4.13.2 ; python_version<'3.13'",
 ]
 readme = "docs/README.md"
-authors = [
-  { name="Andreas Pelme", email="andreas@pelme.se" },
-]
+authors = [{ name = "Andreas Pelme", email = "andreas@pelme.se" }]
 license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -24,23 +22,21 @@ classifiers = [
 
 [dependency-groups]
 dev = [
-    "pre-commit",
-    "mypy",
-    "pyright",
-    "pytest",
     "black",
-    "ruff",
     "django",
     "django-stubs",
-    "jinja2",
-    "starlette",
     "httpx",
+    "jinja2",
     "markdown",
-    "pytest-doctestplus"
+    "mypy",
+    "pre-commit",
+    "pyright",
+    "pytest",
+    "pytest-doctestplus",
+    "ruff",
+    "starlette",
 ]
-docs = [
-    "mkdocs-material==9.5.12",
-]
+docs = ["mkdocs-material==9.5.12"]
 
 [project.urls]
 Homepage = "https://htpy.dev"
@@ -51,38 +47,43 @@ Issues = "https://github.com/pelme/htpy/issues"
 [project.scripts]
 html2htpy = "htpy.html2htpy:main"
 
+
 [build-system]
 requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 
-[tool.ruff]
-line-length = 100
-lint.select = [
-    "F",        # Pyflakes
-    "E",        # pycodestyle error
-    "W",        # pycodestyle warning
-    "I",        # isort
-    "B",        # flake8-bugbear
-    "C4",       # flake8-comprehensions
-    "TCH",      # flake8-type-checking
-    "RUF100",   # yesqa equivalence
-    "UP",       # pyupgrade
-    "TID",      # flake8-tidy-imports
-]
-lint.ignore = [
-    "B904",
-]
 
 [tool.mypy]
 strict = true
 packages = ["htpy", "tests"]
 exclude = ["examples", "scripts"]
 
+
 [tool.pyright]
 include = ["htpy", "tests"]
 strict = ["htpy", "tests"]
 
+
 [tool.pytest.ini_options]
 addopts = "--doctest-glob='docs/*.md'"
+
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "F",      # Pyflakes
+    "E",      # pycodestyle error
+    "W",      # pycodestyle warning
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "TCH",    # flake8-type-checking
+    "RUF100", # yesqa equivalence
+    "UP",     # pyupgrade
+    "TID",    # flake8-tidy-imports
+]
+ignore = ["B904"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 [dependency-groups]
 dev = [
     "pre-commit",
+    "tox>=4.21.2",
+    "tox-uv>=1.23.2",
     { include-group = "docs" },
     { include-group = "mypy" },
     { include-group = "pyright" },
@@ -95,3 +97,70 @@ select = [
     "TID",    # flake8-tidy-imports
 ]
 ignore = ["B904"]
+
+
+[tool.tox]
+env_list = [
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+    "3.14",
+    "docs",
+    "mypy",
+    "pyright",
+    "ruff-format",
+    "ruff-check",
+]
+
+[tool.tox.env_run_base]
+package = "wheel"
+wheel_build_env = ".pkg"
+dependency_groups = ["tests"]
+commands = [
+    [
+        "pytest",
+        "--basetemp={envtmpdir}",
+        "tests",                                # unit tests
+        "{envsitepackagesdir}/htpy",            # doctests
+        { replace = "posargs", extend = true },
+    ],
+]
+
+[tool.tox.env.docs]
+dependency_groups = ["docs"]
+commands = [["mkdocs", "build", "--site-dir={envtmpdir}"]]
+
+[tool.tox.env.mypy]
+dependency_groups = ["tests", "mypy"]
+commands = [
+    [
+        "mypy",
+        { replace = "posargs", default = [
+            "htpy",
+            "tests",
+        ], extend = true },
+    ],
+]
+
+[tool.tox.env.pyright]
+dependency_groups = ["tests", "pyright"]
+commands = [
+    [
+        "pyright",
+        { replace = "posargs", default = [
+            "htpy",
+            "tests",
+        ], extend = true },
+    ],
+]
+
+[tool.tox.env.ruff-format]
+skip_install = true
+dependency_groups = ["ruff"]
+commands = [["ruff", "format", "--check", "{posargs:.}"]]
+
+[tool.tox.env.ruff-check]
+skip_install = true
+dependency_groups = ["ruff"]
+commands = [["ruff", "check", "{posargs:.}"]]


### PR DESCRIPTION
This builds upon #130, to avoid too much conflicts, so that should be merged first.

This uses tox to test the built package instead of putting the source directory on path and testing that.

pytest still runs on Python 3.10-3.14. mypy and pyright only runs on 3.13, but this can be extended if needed. `ruff check` and `ruff format` runs directly instead of via pre-commit (mostly because that is how I've used to run them). New is that the docs is also built, to smoketest the docs build for errors.