### PR TITLE
mypy: enable strict_equality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 strict = true
+strict_equality = true
 packages = ["htpy", "tests"]
 exclude = ["examples", "scripts"]
 


### PR DESCRIPTION
I was surprise this was not being checked, it can catch some errors.