### PR TITLE
Add Tailwind IntelliSense configuration for VS Code

### DIFF
--- a/docs/html2htpy.md
+++ b/docs/html2htpy.md
@@ -200,6 +200,32 @@ body[
 ]
 ```
 
-## VSCode Extension
+## Editor Integration
+
+### VSCode Extension
 
 If you are using VSCode, you can install the [html2htpy](https://marketplace.visualstudio.com/items?itemName=dunderrrrrr.html2htpy) extension to quickly convert HTML to htpy code.
+
+### Tailwind IntelliSense
+
+When using Tailwind CSS with htpy, you can enable IntelliSense for utility classes by adding the following configuration to your VS Code `settings.json`:
+
+```json
+{
+    "tailwindCSS.includeLanguages": {
+        "python": "html"
+    },
+    "tailwindCSS.experimental.classRegex": [
+        // keyword‑args and helper args: class_, base_classes, error_classes, etc.
+        "\\b\\w*class\\w*\\b\\s*=\\s*['\"]([^'\"]*)['\"]",
+        // dict‑style class entries: "class": "..."
+        "['\"]class['\"]\\s*:\\s*['\"]([^'\"]*)['\"]"
+    ]
+}
+```
+
+This configuration enables Tailwind IntelliSense for:
+
+- Keyword arguments: `class_="text-sm text-zinc-50"`
+- Custom helper arguments: `base_classes="flex gap-2"`, `error_classes="text-red-500"`
+- Dictionary-style class entries: `{"class": "flex gap-2"}`

--- a/docs/html2htpy.md
+++ b/docs/html2htpy.md
@@ -200,32 +200,6 @@ body[
 ]
 ```
 
-## Editor Integration
-
-### VSCode Extension
+## VSCode Extension
 
 If you are using VSCode, you can install the [html2htpy](https://marketplace.visualstudio.com/items?itemName=dunderrrrrr.html2htpy) extension to quickly convert HTML to htpy code.
-
-### Tailwind IntelliSense
-
-When using Tailwind CSS with htpy, you can enable IntelliSense for utility classes by adding the following configuration to your VS Code `settings.json`:
-
-```json
-{
-    "tailwindCSS.includeLanguages": {
-        "python": "html"
-    },
-    "tailwindCSS.experimental.classRegex": [
-        // keyword‑args and helper args: class_, base_classes, error_classes, etc.
-        "\\b\\w*class\\w*\\b\\s*=\\s*['\"]([^'\"]*)['\"]",
-        // dict‑style class entries: "class": "..."
-        "['\"]class['\"]\\s*:\\s*['\"]([^'\"]*)['\"]"
-    ]
-}
-```
-
-This configuration enables Tailwind IntelliSense for:
-
-- Keyword arguments: `class_="text-sm text-zinc-50"`
-- Custom helper arguments: `base_classes="flex gap-2"`, `error_classes="text-red-500"`
-- Dictionary-style class entries: `{"class": "flex gap-2"}`

--- a/docs/tailwind.md
+++ b/docs/tailwind.md
@@ -1,0 +1,27 @@
+# Usage with Tailwind CSS
+
+## VS Code IntelliSense
+
+Install *Tailwind CSS IntelliSense* extension.
+
+Add this configuration to your VS Code `settings.json` to enable Tailwind IntelliSense in htpy:
+
+```jsonc
+{
+    "tailwindCSS.includeLanguages": {
+        "python": "html"
+    },
+    "tailwindCSS.experimental.classRegex": [
+        // keyword‑args and helper args: class_, base_classes, error_classes, etc.
+        "\\b\\w*class\\w*\\b\\s*=\\s*['\\\"]([^'\\\"]*)['\\\"]",
+        // dict‑style class entries: "class": "..."
+        "['\\\"]class['\\\"]\\s*:\\s*['\\\"]([^'\\\"]*)['\\\"]"
+    ],
+    ]
+}
+```
+
+This enables autocomplete and on hover for:
+- `class_="text-sm text-zinc-50"`
+- `base_classes="flex gap-2"`
+- `{"class": "flex gap-2"}` 


### PR DESCRIPTION
Adds VS Code configuration for Tailwind CSS IntelliSense to work with htpy's syntax patterns. This enables autocompletion for Tailwind classes in htpy code like `class_="text-sm"`, `base_classes="flex gap-2"`, and `{"class": "bg-blue-500"}`.

### Changes
- Added "Editor Integration" section to `docs/html2htpy.md`
- Added VS Code settings for Tailwind IntelliSense with regex patterns for htpy syntax
- Includes `tailwindCSS.includeLanguages` to enable IntelliSense in Python files

### Configuration
```json
{
    "tailwindCSS.includeLanguages": {
        "python": "html"
    },
    "tailwindCSS.experimental.classRegex": [
        "\\b\\w*class\\w*\\b\\s*=\\s*['\"]([^'\"]*)['\"]",
        "['\"]class['\"]\\s*:\\s*['\"]([^'\"]*)['\"]"
    ]
}
```

Fixes the issue where users had to manually configure regex patterns for Tailwind IntelliSense in htpy projects.