### PR TITLE
Deprecate Renderable.encode().

### DIFF
--- a/src/htpy/_contexts.py
+++ b/src/htpy/_contexts.py
@@ -50,6 +50,11 @@ class ContextProvider(t.Generic[T]):
     ) -> AsyncIterator[str]:
         return aiter_chunks_node(self.node, {**(context or {}), self.context: self.value})  # pyright: ignore [reportUnknownMemberType]
 
+    @deprecated(
+        "Calling .encode() on ContextProvider is deprecated and will be removed in a future release. "  # noqa: E501
+        "Using Starlette? Use htpy.starlette.HtpyResponse for improved performance and convenience. "  # noqa: E501
+        "More info: https://htpy.dev/starlette/"
+    )
     def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
         return str(self).encode(encoding, errors)
 
@@ -84,6 +89,11 @@ class ContextConsumer(t.Generic[T]):
     ) -> AsyncIterator[str]:
         return aiter_chunks_node(self.func(self._get_value(context)), context)  # pyright: ignore
 
+    @deprecated(
+        "Calling .encode() on ContectConsumer is deprecated and will be removed in a future release. "  # noqa: E501
+        "Using Starlette? Use htpy.starlette.HtpyResponse for improved performance and convenience. "  # noqa: E501
+        "More info: https://htpy.dev/starlette/"
+    )
     def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
         return str(self).encode(encoding, errors)
 

--- a/src/htpy/_elements.py
+++ b/src/htpy/_elements.py
@@ -111,6 +111,11 @@ class BaseElement:
             yield x
         yield f"</{self._name}>"
 
+    @deprecated(
+        "Calling .encode() on elements is deprecated and will be removed in a future release. "
+        "Using Starlette? Use htpy.starlette.HtpyResponse for improved performance and convenience. "  # noqa: E501
+        "More info: https://htpy.dev/starlette/"
+    )
     def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
         return str(self).encode(encoding, errors)
 

--- a/src/htpy/_fragments.py
+++ b/src/htpy/_fragments.py
@@ -50,6 +50,11 @@ class Fragment:
     ) -> AsyncIterator[str]:
         return aiter_chunks_node(self._node, context)
 
+    @deprecated(
+        "Calling .encode() on fragments is deprecated and will be removed in a future release. "
+        "Using Starlette? Use htpy.starlette.HtpyResponse for improved performance and convenience. "  # noqa: E501
+        "More info: https://htpy.dev/starlette/"
+    )
     def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
         return str(self).encode(encoding, errors)
 

--- a/src/htpy/_types.py
+++ b/src/htpy/_types.py
@@ -26,11 +26,6 @@ class Renderable(t.Protocol):
         self, context: Mapping[Context[t.Any], t.Any] | None = None
     ) -> AsyncIterator[str]: ...
 
-    # Allow starlette Response.render to directly render this element without
-    # explicitly casting to str:
-    # https://github.com/encode/starlette/blob/5ed55c441126687106109a3f5e051176f88cd3e6/starlette/responses.py#L44-L49
-    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes: ...
-
 
 _ClassNamesDict: t.TypeAlias = dict[str, bool]
 _ClassNames: t.TypeAlias = Iterable[str | None | bool | _ClassNamesDict] | _ClassNamesDict

--- a/src/htpy/_with_children.py
+++ b/src/htpy/_with_children.py
@@ -5,6 +5,11 @@ import typing as t
 
 import markupsafe
 
+try:
+    from warnings import deprecated  # type: ignore[attr-defined,unused-ignore]
+except ImportError:
+    from typing_extensions import deprecated
+
 if t.TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator, Mapping
 
@@ -56,6 +61,11 @@ class _WithChildrenUnbound(t.Generic[C, P, R]):
 
     __html__ = __str__
 
+    @deprecated(
+        "Calling .encode() is deprecated and will be removed in a future release. "
+        "Using Starlette? Use htpy.starlette.HtpyResponse for improved performance and convenience. "  # noqa: E501
+        "More info: https://htpy.dev/starlette/"
+    )
     def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
         return str(self).encode(encoding, errors)
 
@@ -109,6 +119,11 @@ class _WithChildrenBound(t.Generic[C, P, R]):
 
     __html__ = __str__
 
+    @deprecated(
+        "Calling .encode() is deprecated and will be removed in a future release. "
+        "Using Starlette? Use htpy.starlette.HtpyResponse for improved performance and convenience. "  # noqa: E501
+        "More info: https://htpy.dev/starlette/"
+    )
     def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
         return str(self).encode(encoding, errors)
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -83,8 +83,9 @@ def test_html(case: RenderableTestCase) -> None:
 
 
 @pytest.mark.parametrize("case", cases)
-def test_encode(case: RenderableTestCase) -> None:
-    result = case.renderable.encode()
+def test_encode_deprecation_warning(case: RenderableTestCase) -> None:
+    with pytest.warns(DeprecationWarning, match=r"Calling .encode\(\) .*is deprecated"):
+        result = case.renderable.encode()  # type: ignore[attr-defined]
     assert isinstance(result, bytes)
     assert result == case.expected_bytes()
 

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
+import pytest
 from starlette.applications import Starlette
 from starlette.responses import HTMLResponse
 from starlette.routing import Route
@@ -41,7 +42,8 @@ client = TestClient(app)
 
 
 def test_html_response() -> None:
-    response = client.get("/html-response")
+    with pytest.warns(DeprecationWarning, match=r"Calling .encode\(\) .*is deprecated"):
+        response = client.get("/html-response")
     assert response.content == b"<h1>Hello, HTMLResponse!</h1>"
 
 


### PR DESCRIPTION
Prefer using htpy.starlette.HtpyResponse instead of relying on Starlette
calling .encode() on a renderable.

### Relation chain
-  #163
- 👉 #162
-  #161
-  #160