### PR TITLE
docs: Improve the table of contents

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,8 @@ theme:
   name: material
   features:
     - content.code.copy
+    - toc.integrate
+    - navigation.expand
   palette:
     - media: "(prefers-color-scheme)"
       toggle:


### PR DESCRIPTION
There number of pages we have makes it better to show all the pages expanded.

Also, integrating the ToC into the menu avoids having the right menu.

### Relation chain
-  #171
- 👉 #170