### PR TITLE
fix: preserve double underscores in attribute names

### DIFF
--- a/src/htpy/_elements.py
+++ b/src/htpy/_elements.py
@@ -194,7 +194,11 @@ def _python_to_html_name(name: str) -> str:
     name_without_underscore_suffix = name.removesuffix("_")
     if keyword.iskeyword(name_without_underscore_suffix):
         html_name = name_without_underscore_suffix
-    html_name = html_name.replace("_", "-")
+
+    # Preserve double underscores while converting single underscores to
+    # hyphens. This is needed for frameworks like Datastar that use __ as a
+    # modifier delimiter in attribute names (e.g. data-on-click__window).
+    html_name = html_name.replace("__", "\x00").replace("_", "-").replace("\x00", "__")
 
     return html_name
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -103,6 +103,14 @@ def test_underscore_replacement(render: RenderFixture) -> None:
     assert render(result) == ['<button hx-post="/foo">', "click me!", "</button>"]
 
 
+def test_double_underscore_preserved(render: RenderFixture) -> None:
+    # Double underscores should be preserved in attribute names. This is needed
+    # for frameworks like Datastar that use __ as a modifier delimiter
+    # (e.g. data-on-click__window).
+    result = div(data_on_click__window="alert()")
+    assert render(result) == ['<div data-on-click__window="alert()">', "</div>"]
+
+
 class Test_attribute_escape:
     pytestmark = pytest.mark.parametrize(
         "x",


### PR DESCRIPTION
## Problem

`_python_to_html_name()` replaces all underscores with hyphens via `name.replace("_", "-")`. This makes it impossible to express attribute names containing literal double underscores (`__`) through kwargs.

Frameworks like [Datastar](https://data-star.dev/) use `__` as a modifier delimiter in attribute names (e.g. `data-on:click__debounce.300ms`, `data-on:submit__prevent`). Currently these render incorrectly as `data-on:click--debounce.300ms`.

Users can work around this by passing a positional dict instead of kwargs, but this is surprising and undocumented.

## Fix

Replace the blanket `replace("_", "-")` with a sentinel-based approach that preserves `__`:

```python
html_name.replace("__", "\x00").replace("_", "-").replace("\x00", "__")
```

Single underscores still convert to hyphens (existing behavior). Double underscores pass through unchanged.

## Test

Added `test_double_underscore_preserved` verifying `div(data_on_click__window="alert()")` renders as `<div data-on-click__window="alert()">`.

All 433 existing tests pass.