### PR TITLE
Raise ValueError instead of emit FutureWarning on whitespace in CSS shorthand

### DIFF
--- a/src/htpy/_attributes.py
+++ b/src/htpy/_attributes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing as t
-import warnings
 from collections.abc import Iterable
 
 import markupsafe
@@ -55,14 +54,8 @@ def id_class_names_from_css_str(x: t.Any) -> Mapping[str, Attribute]:
         raise ValueError("id/class strings must start with # or .")
 
     if any(ch.isspace() for ch in x):
-        warnings.warn(
-            (
-                "Whitespace in CSS shorthand strings is deprecated and will raise a ValueError "
-                f"in a future release. Please remove the space in '{x}' "
-                "(e.g., use '.a.b' instead of '.a .b')."
-            ),
-            FutureWarning,
-            stacklevel=3,
+        raise ValueError(
+            f'Whitespace is not allowed in class shorthand. String with whitespaces: "{x}"'
         )
 
     parts = x.split(".")

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing as t
-import warnings
 
 import pytest
 from markupsafe import Markup
@@ -169,14 +168,11 @@ def test_id_class_wrong_order() -> None:
 
 @pytest.mark.parametrize("css_str", [".a b", ".a .b", "#a .a ", ".a ", "#a "])
 def test_whitespace_in_class_shorthand(css_str: str) -> None:
-    with pytest.warns(FutureWarning):
+    with pytest.raises(
+        ValueError,
+        match="Whitespace is not allowed in class shorthand.",
+    ):
         div(css_str)
-
-
-def test_no_whitespace_in_class_shorthand() -> None:
-    with warnings.catch_warnings(record=True) as caught:
-        div(".a.b")
-    assert len(caught) == 0
 
 
 def test_id_class_bad_format() -> None:


### PR DESCRIPTION
This reverts commit 3567dae69293e6f02c58d00d90531a84baea0588.

Raise ValueError instead of emit Python warning as mentioned in [release notes](https://github.com/pelme/htpy/releases/tag/26.5.0).
